### PR TITLE
px2-px2dthelper@2.0.4 リリース候補

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,6 +256,7 @@ $ php .px_execute.php "/path/to/target/page_path.html?PX=px2dthelper.change_cont
 
 - PXコマンド `PX=px2dthelper.get.navigation_info` を追加。
 - PXコマンド `PX=px2dthelper.get.all` に `filter` オプションを追加。
+- `PX=px2dthelper.get.all` に含まれる `path_files`, `realpath_files` が、不正な値を返すことがある不具合を修正。
 
 ### pickles2/px2-px2dthelper 2.0.3 (2017年2月6日)
 

--- a/README.md
+++ b/README.md
@@ -160,13 +160,21 @@ $ php .px_execute.php /path/find/content.html?PX=px2dthelper.find_page_content
 
 ナビゲーションシステムを生成するために必要な情報をまとめて取得します。
 
+```bash
+$ php .px_execute.php "/?PX=px2dthelper.get.navigation_info&filter=false"
+```
+
+`filter` オプションは、 `$site->get_bros()` と `$site->get_children()` に渡されます。
+
 #### PX=px2dthelper.get.all
 
 Pickles 2 から複数の情報を一度に取得します。
 
 ```bash
-$ php .px_execute.php /?PX=px2dthelper.get.all
+$ php .px_execute.php "/?PX=px2dthelper.get.all&filter=false"
 ```
+
+`filter` オプションは、 `$site->get_bros()` と `$site->get_children()` に渡されます。
 
 #### PX=px2dthelper.check_editor_mode
 
@@ -247,6 +255,7 @@ $ php .px_execute.php "/path/to/target/page_path.html?PX=px2dthelper.change_cont
 ### pickles2/px2-px2dthelper 2.0.4 (2017年??月??日)
 
 - PXコマンド `PX=px2dthelper.get.navigation_info` を追加。
+- PXコマンド `PX=px2dthelper.get.all` に `filter` オプションを追加。
 
 ### pickles2/px2-px2dthelper 2.0.3 (2017年2月6日)
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -31,9 +31,10 @@ init:
 # Install scripts
 install:
   ## Set PHP.
-  - cinst php --version 7.0.9
-  - SET PATH=C:\tools\php\;%PATH%
-  - cd C:\tools\php
+  - ps: Set-Service wuauserv -StartupType Manual
+  - cinst php --version 7.1.3 -y
+  - SET PATH=C:\tools\php71\;%PATH%
+  - cd C:\tools\php71
   - copy php.ini-production php.ini
   - echo date.timezone="Asia/Tokyo" >> php.ini
   - echo extension_dir=ext >> php.ini

--- a/php/main.php
+++ b/php/main.php
@@ -506,8 +506,8 @@ class main{
 						if( is_object($this->px->site()) ){
 							@$rtn->path_resource_dir = $this->get_path_resource_dir();
 							@$rtn->page_info = $this->px->site()->get_page_info( $request_path );
-							@$rtn->path_files = $this->px->path_files( $request_path );
-							@$rtn->realpath_files = $this->px->realpath_files( $request_path );
+							@$rtn->path_files = $this->px->path_files();
+							@$rtn->realpath_files = $this->px->realpath_files();
 							@$rtn->navigation_info = $this->get_navigation_info( $request_path, $sitemap_filter_options($this->px, $this->command[2]) );
 						}
 

--- a/tests/getAllTest.php
+++ b/tests/getAllTest.php
@@ -101,6 +101,72 @@ class getAllTest extends PHPUnit_Framework_TestCase{
 	}//testGetAll()
 
 	/**
+	 * PX=px2dthelper.get.all のテスト
+	 */
+	public function testGetAllDeepPage(){
+
+		// Pickles 2 実行
+		$output = $this->passthru( ['php', __DIR__.'/testData/standard/.px_execute.php', '/editsample/?PX=px2dthelper.get.all' ] );
+		// var_dump($output);
+		$json = json_decode( $output );
+		// var_dump($json);
+		$this->assertTrue( is_object($json) );
+
+		// Pickles 2 のバージョン番号
+		$output = json_decode($this->passthru( ['php', __DIR__.'/testData/standard/.px_execute.php', '/editsample/?PX=api.get.version' ] ));
+		$this->assertEquals( $json->version->pxfw, $output );
+
+		// px2dthelper のバージョン番号
+		$output = json_decode($this->passthru( ['php', __DIR__.'/testData/standard/.px_execute.php', '/editsample/?PX=px2dthelper.version' ] ));
+		$this->assertEquals( $json->version->px2dthelper, $output );
+
+		// path_resource_dir
+		$output = json_decode($this->passthru( ['php', __DIR__.'/testData/standard/.px_execute.php', '/editsample/?PX=px2dthelper.get.path_resource_dir' ] ));
+		$this->assertEquals( $json->path_resource_dir, $output );
+
+		// custom_fields
+		$output = json_decode($this->passthru( ['php', __DIR__.'/testData/standard/.px_execute.php', '/editsample/?PX=px2dthelper.get.custom_fields' ] ));
+		$this->assertEquals( $json->custom_fields, $output );
+
+		// realpath_homedir
+		$output = json_decode($this->passthru( ['php', __DIR__.'/testData/standard/.px_execute.php', '/editsample/?PX=api.get.path_homedir' ] ));
+		$this->assertEquals( $json->realpath_homedir, $output );
+
+		// path_controot
+		$output = json_decode($this->passthru( ['php', __DIR__.'/testData/standard/.px_execute.php', '/editsample/?PX=api.get.path_controot' ] ));
+		$this->assertEquals( $json->path_controot, $output );
+
+		// realpath_docroot
+		$output = json_decode($this->passthru( ['php', __DIR__.'/testData/standard/.px_execute.php', '/editsample/?PX=api.get.path_docroot' ] ));
+		$this->assertEquals( $json->realpath_docroot, $output );
+
+		// page_info
+		$output = json_decode($this->passthru( ['php', __DIR__.'/testData/standard/.px_execute.php', '/editsample/?PX=api.get.page_info&path=/editsample/' ] ));
+		$this->assertEquals( $json->page_info, $output );
+
+		// path_files
+		$output = json_decode($this->passthru( ['php', __DIR__.'/testData/standard/.px_execute.php', '/editsample/?PX=api.get.path_files&path=/editsample/' ] ));
+		$this->assertEquals( $json->path_files, $output );
+
+		// realpath_files
+		$output = json_decode($this->passthru( ['php', __DIR__.'/testData/standard/.px_execute.php', '/editsample/?PX=api.get.realpath_files&path=/editsample/' ] ));
+		$this->assertEquals( $json->realpath_files, $output );
+
+		// navigaton_info
+		$output = json_decode($this->passthru( ['php', __DIR__.'/testData/standard/.px_execute.php', '/editsample/?PX=px2dthelper.get.navigation_info' ] ));
+		$this->assertEquals( $json->navigation_info, $output );
+
+
+		// 後始末
+		$output = $this->passthru( [
+			'php',
+			__DIR__.'/testData/standard/.px_execute.php' ,
+			'/?PX=clearcache' ,
+		] );
+
+	}//testGetAllDeepPage()
+
+	/**
 	 * PX=px2dthelper.get.all を、before_sitemap の環境で実行するテスト
 	 */
 	public function testGetAllBeforeSitemap(){

--- a/tests/getNavigationInfoTest.php
+++ b/tests/getNavigationInfoTest.php
@@ -53,8 +53,23 @@ class getNavigationInfo extends PHPUnit_Framework_TestCase{
 		$this->assertEquals( $json_test1_load->parent_info, $json_toppage->page_info );
 		$this->assertEquals( $json_test1_load->bros, $json_toppage->children );
 		$this->assertEquals( $json_test1_load->bros_info, $json_toppage->children_info );
-		$this->assertEquals( count($json_test1_load->children), 0 );
-		$this->assertEquals( count($json_test1_load->children_info), 0 );
+		$this->assertEquals( count($json_test1_load->children), 2 );
+		$this->assertEquals( count($json_test1_load->children_info), 2 );
+
+
+		// 下層ページ取得(filter: false)
+		$output_test1_load = $this->passthru( ['php', __DIR__.'/testData/standard/.px_execute.php', '/test1_load.html?PX=px2dthelper.get.navigation_info&filter=false' ] );
+		// var_dump($output_test1_load);
+		$json_test1_load = json_decode( $output_test1_load );
+		// var_dump($json_test1_load);
+		$this->assertTrue( is_array($json_test1_load->breadcrumb) );
+		$this->assertEquals( count($json_test1_load->breadcrumb), 1 );
+		$this->assertEquals( $json_test1_load->breadcrumb_info[0], $json_toppage->page_info );
+		$this->assertEquals( $json_test1_load->parent_info, $json_toppage->page_info );
+		$this->assertEquals( count($json_test1_load->bros), count($json_toppage->children)+1 );
+		$this->assertEquals( count($json_test1_load->bros_info), count($json_toppage->children_info)+1 );
+		$this->assertEquals( count($json_test1_load->children), 3 );
+		$this->assertEquals( count($json_test1_load->children_info), 3 );
 
 
 		// 後始末

--- a/tests/testData/standard/px-files/sitemaps/sitemap.csv
+++ b/tests/testData/standard/px-files/sitemaps/sitemap.csv
@@ -1,9 +1,13 @@
 "*path","*content","*id","*title","*title_breadcrumb","*title_h1","*title_label","*title_full","*logical_path","*list_flg","*layout","*orderby","*keywords","*description","*category_top_flg"
 "/",,,"ホーム",,,,,,1,"top",,,,
 "/test1_load.html",,,"Test for load",,,,,,1,,,,,1
+"/test1_load_children/index.html",,,"Test for load – children 1",,,,,"/test1_load.html",1,,,,,1
+"/test1_load_children/index2.html",,,"Test for load – children 2 (list_flg:0)",,,,,"/test1_load.html",0,,,,,1
+"/test1_load_children/index3.html",,,"Test for load – children 3",,,,,"/test1_load.html",1,,,,,1
 "/test1_build_css.html",,,"Test for build_css",,,,,,1,,,,,1
 "/test1_build_js.html",,,"Test for build_js",,,,,,1,,,,,1
 "/styleguides/index.html",,,"Style Guides",,,,,,1,,,,,1
 "/editsample/index.html",,,"Edit sample",,,,,,1,,,,,1
 "/editsample/php_build.html",,,"Build by PHP",,,,,"/editsample/index.html",1,,,,,1
 "/editor_modes/not_exists.html",,,"content not exists",,,,,,1,,,,,1
+"/list_flg_0/index.html",,,"list_flg: 0",,,,,,0,,,,,1


### PR DESCRIPTION
- PXコマンド `PX=px2dthelper.get.navigation_info`, `PX=px2dthelper.get.all` に `filter` オプションを追加。
- `PX=px2dthelper.get.all` に含まれる path_files, realpath_files が不正な値を返すことがある不具合を修正。