### PR TITLE
Develop

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,6 +307,8 @@ $ php .px_execute.php "/path/to/target/page_path.html?PX=px2dthelper.packages.ge
 - PXコマンド `PX=px2dthelper.packages.get_path_composer_root_dir` を追加。
 - PXコマンド `PX=px2dthelper.packages.get_path_npm_root_dir` を追加。
 - PXコマンド `PX=px2dthelper.get.all` に `path` オプションを追加。
+- PXコマンド `PX=px2dthelper.get.all` の結果に `path_type` を追加。
+- PXコマンド `PX=px2dthelper.get.all` で、`path` オプションに id を指定してエイリアスページの情報を取得できるようになった。
 
 ### pickles2/px2-px2dthelper 2.0.5 (2017年5月30日)
 

--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ $ php .px_execute.php "/?PX=px2dthelper.get.all&filter=false&path=/index.html"
 コンテンツの編集モードを取得します。
 
 ```bash
-$ php .px_execute.php "/target/path.html?PX=px2dthelper.check_editor_mode"
+$ php .px_execute.php "/?PX=px2dthelper.check_editor_mode&path=/target/path.html"
 ```
 
 #### PX=px2dthelper.search_sitemap
@@ -306,7 +306,7 @@ $ php .px_execute.php "/path/to/target/page_path.html?PX=px2dthelper.packages.ge
 - PXコマンド `PX=px2dthelper.packages.get_theme_package_list` を追加。
 - PXコマンド `PX=px2dthelper.packages.get_path_composer_root_dir` を追加。
 - PXコマンド `PX=px2dthelper.packages.get_path_npm_root_dir` を追加。
-- PXコマンド `PX=px2dthelper.get.all` に `path` オプションを追加。
+- PXコマンド `PX=px2dthelper.get.all`, `PX=px2dthelper.check_editor_mode` に `path` オプションを追加。
 - PXコマンド `PX=px2dthelper.get.all` の結果に `path_type` を追加。
 - PXコマンド `PX=px2dthelper.get.all` で、`path` オプションに id を指定してエイリアスページの情報を取得できるようになった。
 

--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ $ php .px_execute.php "/?PX=px2dthelper.get.navigation_info&filter=false"
 Pickles 2 から複数の情報を一度に取得します。
 
 ```bash
-$ php .px_execute.php "/?PX=px2dthelper.get.all&filter=false"
+$ php .px_execute.php "/?PX=px2dthelper.get.all&filter=false&path=/index.html"
 ```
 
 `filter` オプションは、 `$site->get_bros()` と `$site->get_children()` に渡されます。
@@ -306,6 +306,7 @@ $ php .px_execute.php "/path/to/target/page_path.html?PX=px2dthelper.packages.ge
 - PXコマンド `PX=px2dthelper.packages.get_theme_package_list` を追加。
 - PXコマンド `PX=px2dthelper.packages.get_path_composer_root_dir` を追加。
 - PXコマンド `PX=px2dthelper.packages.get_path_npm_root_dir` を追加。
+- PXコマンド `PX=px2dthelper.get.all` に `path` オプションを追加。
 
 ### pickles2/px2-px2dthelper 2.0.5 (2017年5月30日)
 

--- a/php/main.php
+++ b/php/main.php
@@ -344,7 +344,7 @@ class main{
 						break;
 				}
 			}else{
-				$realpath_data_dir = $this->get_realpath_data_dir();
+				$realpath_data_dir = $this->get_realpath_data_dir($page_path);
 				if( $this->px->fs()->is_file( $realpath_data_dir.'/data.json' ) ){
 					$rtn = 'html.gui';
 				}

--- a/php/main.php
+++ b/php/main.php
@@ -517,17 +517,23 @@ class main{
 						@$rtn->realpath_docroot = $this->px->get_path_docroot();
 						@$rtn->realpath_data_dir = $this->get_realpath_data_dir( $request_path );
 
-						@$rtn->path_resource_dir = false;
 						@$rtn->page_info = false;
+						@$rtn->path_type = false;
 						@$rtn->path_files = false;
+						@$rtn->path_resource_dir = false;
 						@$rtn->realpath_files = false;
 						@$rtn->navigation_info = false;
 
 						if( is_object($this->px->site()) ){
-							@$rtn->path_resource_dir = $this->get_path_resource_dir( $request_path );
 							@$rtn->page_info = $this->px->site()->get_page_info( $request_path );
-							@$rtn->path_files = $this->path_files( $request_path );
-							@$rtn->realpath_files = $this->realpath_files( $request_path );
+							@$rtn->path_type = $this->px->get_path_type( $rtn->page_info['path'] );
+							if( $rtn->path_type != 'alias' ){
+								@$rtn->path_files = $this->path_files( $request_path );
+								@$rtn->path_resource_dir = $this->get_path_resource_dir( $request_path );
+								@$rtn->realpath_files = $this->realpath_files( $request_path );
+							}else{
+								@$rtn->realpath_data_dir = false;
+							}
 							@$rtn->navigation_info = $this->get_navigation_info( $request_path, $sitemap_filter_options($this->px, $this->command[2]) );
 						}
 

--- a/php/main.php
+++ b/php/main.php
@@ -551,7 +551,11 @@ class main{
 
 			case 'check_editor_mode':
 				// コンテンツの編集モードを調べる
-				print $std_output->data_convert( $this->check_editor_mode() );
+				$request_path = $this->px->req()->get_param('path');
+				if( !strlen( $request_path ) ){
+					$request_path = $this->px->req()->get_request_file_path();
+				}
+				print $std_output->data_convert( $this->check_editor_mode( $request_path ) );
 				exit;
 				break;
 

--- a/tests/getAllTest.php
+++ b/tests/getAllTest.php
@@ -24,6 +24,7 @@ class getAllTest extends PHPUnit_Framework_TestCase{
 		$json = json_decode( $output );
 		// var_dump($json);
 		$this->assertTrue( is_object($json) );
+		$this->assertEquals( $json->path_type, 'normal' );
 
 		// Pickles 2 のバージョン番号
 		$output = json_decode($this->passthru( ['php', __DIR__.'/testData/standard/.px_execute.php', '/?PX=api.get.version' ] ));
@@ -134,6 +135,39 @@ class getAllTest extends PHPUnit_Framework_TestCase{
 		] );
 
 	}//testGetAllByPageId()
+
+	/**
+	 * PX=px2dthelper.get.all でページIDをキーにaliasページの情報を得るテスト
+	 */
+	public function testGetAllOfAliasPageByPageId(){
+
+		// Pickles 2 実行
+		$output = $this->passthru( ['php', __DIR__.'/testData/standard/.px_execute.php', '/?PX=px2dthelper.get.all&path=alias_test' ] );
+		// var_dump($output);
+		$json = json_decode( $output );
+		// var_dump($json);
+
+		$this->assertEquals( $json->page_info->id, 'alias_test' );
+		$this->assertEquals( $json->page_info->title, 'Alias Test' );
+		$this->assertEquals( $json->path_type, 'alias' );
+		$this->assertFalse( $json->path_files );
+		$this->assertFalse( $json->path_resource_dir );
+		$this->assertFalse( $json->realpath_files );
+		$this->assertFalse( $json->realpath_data_dir );
+		$this->assertEquals( $json->navigation_info->page_info->id, 'alias_test' );
+		$this->assertEquals( $json->navigation_info->parent, '' );
+		$this->assertEquals( count($json->navigation_info->bros), 7 );
+		$this->assertEquals( count($json->navigation_info->children), 0 );
+
+
+		// 後始末
+		$output = $this->passthru( [
+			'php',
+			__DIR__.'/testData/standard/.px_execute.php' ,
+			'/?PX=clearcache' ,
+		] );
+
+	}//testGetAllOfAliasPageByPageId()
 
 	/**
 	 * PX=px2dthelper.get.all で深いページの情報を得るテスト

--- a/tests/getAllTest.php
+++ b/tests/getAllTest.php
@@ -101,7 +101,42 @@ class getAllTest extends PHPUnit_Framework_TestCase{
 	}//testGetAll()
 
 	/**
-	 * PX=px2dthelper.get.all のテスト
+	 * PX=px2dthelper.get.all でページIDをキーに情報を得るテスト
+	 */
+	public function testGetAllByPageId(){
+
+		// Pickles 2 実行
+		$output = $this->passthru( ['php', __DIR__.'/testData/standard/.px_execute.php', '/test1_load.html?PX=px2dthelper.get.all' ] );
+		// var_dump($output);
+		$json1 = json_decode( $output );
+		// var_dump($json1);
+
+		$output = $this->passthru( ['php', __DIR__.'/testData/standard/.px_execute.php', '/?PX=px2dthelper.get.all&path=/test1_load.html' ] );
+		// var_dump($output);
+		$json2 = json_decode( $output );
+		// var_dump($json2);
+
+		$output = $this->passthru( ['php', __DIR__.'/testData/standard/.px_execute.php', '/?PX=px2dthelper.get.all&path=test1_load' ] );
+		// var_dump($output);
+		$json3 = json_decode( $output );
+		// var_dump($json3);
+		// var_dump($json3->page_info);
+
+		$this->assertEquals( $json1, $json2 );
+		$this->assertEquals( $json2, $json3 );
+
+
+		// 後始末
+		$output = $this->passthru( [
+			'php',
+			__DIR__.'/testData/standard/.px_execute.php' ,
+			'/?PX=clearcache' ,
+		] );
+
+	}//testGetAllByPageId()
+
+	/**
+	 * PX=px2dthelper.get.all で深いページの情報を得るテスト
 	 */
 	public function testGetAllDeepPage(){
 

--- a/tests/getNavigationInfoTest.php
+++ b/tests/getNavigationInfoTest.php
@@ -37,9 +37,9 @@ class getNavigationInfo extends PHPUnit_Framework_TestCase{
 		$this->assertTrue( is_array($json_toppage->bros_info) );
 		$this->assertEquals( count($json_toppage->bros_info), 1 );
 		$this->assertTrue( is_array($json_toppage->children) );
-		$this->assertEquals( count($json_toppage->children), 6 );
+		$this->assertEquals( count($json_toppage->children), 7 );
 		$this->assertTrue( is_array($json_toppage->children_info) );
-		$this->assertEquals( count($json_toppage->children_info), 6 );
+		$this->assertEquals( count($json_toppage->children_info), 7 );
 
 
 		// 下層ページ取得

--- a/tests/mainTest.php
+++ b/tests/mainTest.php
@@ -199,6 +199,11 @@ class mainTest extends PHPUnit_Framework_TestCase{
 		// var_dump($output);
 		$this->assertEquals( 'html', $output );
 
+		$outputByPath = $this->passthru( [ 'php', __DIR__.'/testData/standard/.px_execute.php', '/?PX=px2dthelper.check_editor_mode&path=/editor_modes/index.html' ] );
+		$outputByPath = json_decode($outputByPath);
+		// var_dump($outputByPath);
+		$this->assertEquals( $outputByPath, $output );
+
 		$output = $this->passthru( [ 'php', __DIR__.'/testData/standard/.px_execute.php', '/editor_modes/html.html?PX=px2dthelper.check_editor_mode' ] );
 		$output = json_decode($output);
 		// var_dump($output);

--- a/tests/testData/standard/px-files/sitemaps/sitemap.csv
+++ b/tests/testData/standard/px-files/sitemaps/sitemap.csv
@@ -1,6 +1,6 @@
 "*path","*content","*id","*title","*title_breadcrumb","*title_h1","*title_label","*title_full","*logical_path","*list_flg","*layout","*orderby","*keywords","*description","*category_top_flg"
 "/",,,"ホーム",,,,,,1,"top",,,,
-"/test1_load.html",,,"Test for load",,,,,,1,,,,,1
+"/test1_load.html",,"test1_load","Test for load",,,,,,1,,,,,1
 "/test1_load_children/index.html",,,"Test for load – children 1",,,,,"/test1_load.html",1,,,,,1
 "/test1_load_children/index2.html",,,"Test for load – children 2 (list_flg:0)",,,,,"/test1_load.html",0,,,,,1
 "/test1_load_children/index3.html",,,"Test for load – children 3",,,,,"/test1_load.html",1,,,,,1
@@ -11,3 +11,4 @@
 "/editsample/php_build.html",,,"Build by PHP",,,,,"/editsample/index.html",1,,,,,1
 "/editor_modes/not_exists.html",,,"content not exists",,,,,,1,,,,,1
 "/list_flg_0/index.html",,,"list_flg: 0",,,,,,0,,,,,1
+"alias:/test1_build_js.html",,"alias_test","Alias Test",,,,,,1,,,,,1


### PR DESCRIPTION
- PXコマンド `PX=px2dthelper.get.all` に `path` オプションを追加。
- PXコマンド `PX=px2dthelper.check_editor_mode` に `path` オプションを追加。
- PXコマンド `PX=px2dthelper.get.all` の結果に `path_type` を追加。
- PXコマンド `PX=px2dthelper.get.all` で、`path` オプションに id を指定してエイリアスページの情報を取得できるようになった。